### PR TITLE
Allowing strings for file.contents

### DIFF
--- a/lib/src.js
+++ b/lib/src.js
@@ -18,12 +18,20 @@ function src(files, options) {
 
 	srcStream._read = function () {
 		files.forEach(function (file) {
-			this.push(file instanceof File ? file : new File({
-				contents: file.contents instanceof Buffer ? file.contents : new Buffer(''),
-				cwd: file.cwd || '',
-				base: file.base || '',
-				path: file.path
-			}));
+			var contents;
+			if (file instanceof File) {
+				this.push(file);
+			} else if (typeof file === 'object') {
+				contents = file.contents || '';
+				contents = (contents instanceof Buffer) ? contents : new Buffer(contents);
+				this.push(new File({
+					contents: contents,
+					cwd:      file.cwd || '',
+					base:     file.base || '',
+					path:     file.path
+				}));
+			}
+
 		}, this);
 
 		this.push(null);


### PR DESCRIPTION
This PR changes the way `file.contents` is evaluated slightly. Previously, if your `file.contents` wasn't already a `Buffer` it would be replaced with `new Buffer('')`. Updated logic to Bufferize an extant string. Logic was starting to cramp up so I expanded it a bit.

mocha tests pass but I haven't real-person tested this yet.
